### PR TITLE
Enable segmentation mask visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ Segmentation quality can be evaluated with:
 ```
 python evaluation.py <output_path> --evaluate-segmentation
 ```
+Passing `--outputImg` saves colored predictions and ground truth masks under
+`<output_path>/segmentation`.
 
 ### 5) Export/ Evaluate repeatability on SIFT
 - Refer to another project: [Feature-preserving image denoising with multiresolution filters](https://github.com/eric-yyjau/image_denoising_matching)


### PR DESCRIPTION
## Summary
- allow evaluation to output segmentation images when `--outputImg` is used
- document how to save the segmentation images