### PR TITLE
Add Cityscapes SuperPoint training config

### DIFF
--- a/configs/superpoint_cityscapes_train.yaml
+++ b/configs/superpoint_cityscapes_train.yaml
@@ -1,0 +1,90 @@
+# Configuration for training SuperPoint on the Cityscapes dataset
+# Includes segmentation masks with 19 classes
+
+data:
+    dataset: 'Cityscapes'
+    root: 'datasets/Cityscapes'  # path to Cityscapes images
+    segmentation_labels: 'datasets/Cityscapes/gtFine'  # segmentation masks
+    cache_in_memory: false
+    load_segmentation: true
+    num_segmentation_classes: 19
+    preprocessing:
+        resize: [512, 1024]  # images are downsampled for training
+    augmentation:
+        photometric:
+            enable: true
+            primitives: [
+                'random_brightness', 'random_contrast', 'additive_speckle_noise',
+                'additive_gaussian_noise', 'additive_shade', 'motion_blur']
+            params:
+                random_brightness: {max_abs_change: 50}
+                random_contrast: {strength_range: [0.5, 1.5]}
+                additive_gaussian_noise: {stddev_range: [0, 10]}
+                additive_speckle_noise: {prob_range: [0, 0.0035]}
+                additive_shade:
+                    transparency_range: [-0.5, 0.5]
+                    kernel_size_range: [100, 150]
+                motion_blur: {max_kernel_size: 3}
+        homographic:
+            enable: false  # not implemented
+    warped_pair:
+        enable: true
+        params:
+            translation: true
+            rotation: true
+            scaling: true
+            perspective: true
+            scaling_amplitude: 0.2
+            perspective_amplitude_x: 0.2
+            perspective_amplitude_y: 0.2
+            patch_ratio: 0.85
+            max_angle: 1.57
+            allow_artifacts: true
+        valid_border_margin: 3
+
+front_end_model: 'Train_model_heatmap'  # use heatmap detector
+training:
+    workers_train: 4
+    workers_val: 2
+
+
+model:
+    name: 'SuperPointNet_gauss2'
+    params: {}
+    detector_loss:
+        loss_type: 'softmax'
+
+    batch_size: 8
+    eval_batch_size: 8
+    learning_rate: 0.0001  # reasonable learning rate
+    detection_threshold: 0.015
+    lambda_loss: 1
+    lambda_segmentation: 1.0
+    num_segmentation_classes: 19
+    nms: 4
+    dense_loss:
+        enable: false
+        params:
+            descriptor_dist: 4
+            lambda_d: 800
+    sparse_loss:
+        enable: true
+        params:
+            num_matching_attempts: 1000
+            num_masked_non_matches_per_match: 100
+            lamda_d: 1
+            dist: 'cos'
+            method: '2d'
+    other_settings: 'train 2d, gauss 0.2'
+
+retrain: True
+reset_iter: True
+train_iter: 170000
+validation_interval: 2000
+tensorboard_interval: 400
+save_interval: 2000
+validation_size: 5
+truncate: 100
+
+pretrained:
+    # pretrained: 'logs/superpoint_coco_heat2_0/checkpoints/superPointNet_90000_checkpoint.pth.tar'


### PR DESCRIPTION
## Summary
- add `superpoint_cityscapes_train.yaml` describing how to train with Cityscapes segmentation labels