### PR TITLE
Standardize segmentation mask format

### DIFF
--- a/Train_model_heatmap.py
+++ b/Train_model_heatmap.py
@@ -328,6 +328,7 @@ class Train_model_heatmap(Train_model_frontend):
         if self.lambda_segmentation > 0 and sample.get("segmentation_mask") is not None:
             if "segmentation" in outs:
                 seg_pred = outs["segmentation"]
+                # target mask provided as (H, W) long tensor
                 seg_target = sample["segmentation_mask"].long().to(self.device)
                 if seg_pred.shape[-2:] != seg_target.shape[-2:]:
                     seg_pred = F.interpolate(

--- a/datasets/Cityscapes.py
+++ b/datasets/Cityscapes.py
@@ -10,7 +10,11 @@ from utils.tools import dict_update
 
 
 class Cityscapes(data.Dataset):
-    """Dataset loader for Cityscapes images and semantic labels."""
+    """Dataset loader for Cityscapes images and semantic labels.
+
+    ``segmentation_mask`` is returned as a ``torch.long`` tensor with shape
+    ``(H, W)`` when ``load_segmentation`` is enabled.
+    """
 
     # default configuration similar to Coco dataset
     default_config = {
@@ -82,6 +86,7 @@ class Cityscapes(data.Dataset):
             else:
                 logging.warning('Missing segmentation label file: %s', mask_path)
                 seg_mask = torch.zeros((H, W), dtype=torch.long)
+            # semantic segmentation mask with dtype long and shape (H, W)
             output['segmentation_mask'] = seg_mask
 
         return output

--- a/datasets/Coco.py
+++ b/datasets/Coco.py
@@ -14,6 +14,12 @@ from utils.utils import filter_points
 from pycocotools.coco import COCO
 
 class Coco(data.Dataset):
+    """COCO dataset loader.
+
+    The returned sample may include ``segmentation_mask`` with shape ``(H, W)``
+    and dtype ``torch.long`` when segmentation annotations are available.
+    """
+
     default_config = {
         'labels': None,
         'segmentation_labels': None,
@@ -294,7 +300,8 @@ class Coco(data.Dataset):
                     anno_mask = self.coco.annToMask(ann)
                     anno_mask = cv2.resize(anno_mask, (W,H), interpolation=cv2.INTER_NEAREST)
                     mask = np.maximum(mask, anno_mask)
-            input['segmentation_mask'] = torch.tensor(mask, dtype=torch.uint8).view(1, H, W)
+            # store instance segmentation as (H, W) tensor with dtype long
+            input['segmentation_mask'] = torch.tensor(mask, dtype=torch.long)
 
         if self.config.get('num_segmentation_classes', 0) > 0:
             seg_path = None

--- a/datasets/CocoPanoptic.py
+++ b/datasets/CocoPanoptic.py
@@ -13,7 +13,11 @@ from settings import DATA_PATH
 
 
 class CocoPanoptic(Coco):
-    """COCO dataset with panoptic segmentation support."""
+    """COCO dataset with panoptic segmentation support.
+
+    When ``load_panoptic`` is enabled, ``segmentation_mask`` is returned as a
+    ``torch.long`` tensor of shape ``(H, W)``.
+    """
 
     default_config = Coco.default_config.copy()
     # extra switch to enable panoptic loading
@@ -74,6 +78,7 @@ class CocoPanoptic(Coco):
                             num_cls,
                         )
                     cat_map = np.clip(cat_map, 0, num_cls - 1)
+                # panoptic segmentation mask returned as (H, W) long tensor
                 input_dict['segmentation_mask'] = torch.tensor(cat_map, dtype=torch.long)
             else:
                 # skip mask if panoptic file missing

--- a/evaluation.py
+++ b/evaluation.py
@@ -80,6 +80,9 @@ def to3dim(img):
 def compute_miou(pred_mask, gt_mask, num_classes=None):
     """Compute mean Intersection over Union for segmentation masks.
 
+    Both ``pred_mask`` and ``gt_mask`` are expected to have shape ``(H, W)``
+    with integer class ids.
+
     Parameters
     ----------
     pred_mask : np.ndarray
@@ -227,7 +230,10 @@ def overlay_mask(image, mask, alpha=0.5, num_classes=None, class_names=None, cla
     return overlay
 
 def smooth_mask(mask, kernel_size=3):
-    """Apply simple morphological post-processing to clean up a mask."""
+    """Apply simple morphological post-processing to clean up a mask.
+
+    ``mask`` should be an array of shape ``(H, W)`` containing class ids.
+    """
     kernel = np.ones((kernel_size, kernel_size), np.uint8)
     mask = cv2.morphologyEx(mask.astype(np.uint8), cv2.MORPH_OPEN, kernel)
     mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, kernel)


### PR DESCRIPTION
## Summary
- standardize returned segmentation mask format to `(H, W)` `torch.long`
- document mask format in Coco, CocoPanoptic and Cityscapes datasets
- adjust Coco instance mask creation
- update panoptic, cityscapes loaders and training comments
- clarify mask expectations in evaluation helpers

## Testing
- `python -m py_compile Train_model_heatmap.py datasets/Cityscapes.py datasets/Coco.py datasets/CocoPanoptic.py evaluation.py`

------
https://chatgpt.com/codex/tasks/task_e_685e74c9239883299552791a8f7e68a3