### PR TITLE
Fix evaluation mode for pretrained models

### DIFF
--- a/Val_model_heatmap.py
+++ b/Val_model_heatmap.py
@@ -88,6 +88,8 @@ class Val_model_heatmap(SuperPointFrontend_torch):
                 "Ensure 'num_segmentation_classes' matches the training setup."
             ) from err
         self.net = self.net.to(self.device)
+        # ensure evaluation mode so batch norm layers use stored statistics
+        self.net.eval()
         logging.info('successfully load pretrained model from: %s', self.weights_path)
         pass
 

--- a/Val_model_subpixel.py
+++ b/Val_model_subpixel.py
@@ -45,6 +45,8 @@ class Val_model_subpixel(object):
         self.net.load_state_dict(checkpoint['model_state_dict'])
 
         self.net = self.net.to(self.device)
+        # use evaluation mode to avoid batch norm issues with small batches
+        self.net.eval()
         logging.info('successfully load pretrained model from: %s', self.weights_path)
         pass
 

--- a/models/model_wrap.py
+++ b/models/model_wrap.py
@@ -108,7 +108,8 @@ class SuperPointFrontend_torch(object):
             # torch.no_grad(
         # self.net = self.net.cuda()
         self.net = self.net.to(self.device)
-        # self.net.eval()
+        # switch to eval mode so batchnorm layers rely on stored statistics
+        self.net.eval()
 
     def net_parallel(self):
         print("=== Let's use", torch.cuda.device_count(), "GPUs!")


### PR DESCRIPTION
## Summary
- call `eval()` after loading pretrained models
- add comments explaining why