### PR TITLE
Add JSON mapping for COCO panoptic conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,15 @@ datasets/ ($DATA_DIR)
 - MS-COCO 2017
     - [MS-COCO 2017 link](http://cocodataset.org/#download)
     - For panoptic training download the panoptic annotations and place the corresponding folders `panoptic_train2017/` and `panoptic_val2017/` with their JSON files under `COCO/annotations`.
-    - Use `utils/coco_panoptic_to_cs34.py` to convert panoptic PNGs to Cityscapes-34 labels when training semantic segmentation with 34 classes.
+    - Use `utils/coco_panoptic_to_cs34.py` to convert panoptic PNGs to Cityscapes-34 labels when training semantic segmentation with 34 classes. Example:
+
+      ```bash
+      python utils/coco_panoptic_to_cs34.py \
+          --src panoptic_val2017 \
+          --ann annotations/panoptic_val2017.json \
+          --categories annotations/panoptic_coco_categories.json \
+          --dst cs34_masks
+      ```
 - HPatches
     - [HPatches link](http://icvl.ee.ic.ac.uk/vbalnt/hpatches/hpatches-sequences-release.tar.gz)
 


### PR DESCRIPTION
## Summary
- extend `coco_panoptic_to_cs34.py` to read panoptic JSON annotations
- load COCO category labels from `panoptic_coco_categories.json`
- convert each panoptic PNG using segment and category info
- document updated usage of the script in README