### PR TITLE
Add CS34 mask option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,15 +65,17 @@ datasets/ ($DATA_DIR)
 - MS-COCO 2017
     - [MS-COCO 2017 link](http://cocodataset.org/#download)
     - For panoptic training download the panoptic annotations and place the corresponding folders `panoptic_train2017/` and `panoptic_val2017/` with their JSON files under `COCO/annotations`.
-    - Use `utils/coco_panoptic_to_cs34.py` to convert panoptic PNGs to Cityscapes-34 labels when training semantic segmentation with 34 classes. Example:
+    - Use `utils/coco_panoptic_to_cs34.py` to convert panoptic PNGs to Cityscapes-34 labels when training semantic segmentation with 34 classes. The script writes grayscale masks which can be placed under `panoptic_cs34_train2017/` and `panoptic_cs34_val2017/`.
+      Example:
 
       ```bash
       python utils/coco_panoptic_to_cs34.py \
           --src panoptic_val2017 \
           --ann annotations/panoptic_val2017.json \
           --categories annotations/panoptic_coco_categories.json \
-          --dst cs34_masks
+          --dst panoptic_cs34_val2017
       ```
+    - Set `use_cs34_masks: true` in your configuration to load these grayscale masks instead of the standard panoptic labels. When enabled, the JSON annotations are not required.
 - HPatches
     - [HPatches link](http://icvl.ee.ic.ac.uk/vbalnt/hpatches/hpatches-sequences-release.tar.gz)
 

--- a/configs/superpoint_coco_train_heatmap.yaml
+++ b/configs/superpoint_coco_train_heatmap.yaml
@@ -16,7 +16,10 @@ data:
     # Adding COCO segmentation tasks
     load_segmentation: false
     load_panoptic: true  # set true to train with panoptic labels
-    num_segmentation_classes: 201 
+    # use grayscale masks from panoptic_cs34_* folders
+    use_cs34_masks: true
+    # Set to 34 when using CS-34 masks under panoptic_cs34_* folders
+    num_segmentation_classes: 34
     preprocessing:
         resize: [240, 320]
         # resize: [480, 640]

--- a/datasets/CocoPanoptic.py
+++ b/datasets/CocoPanoptic.py
@@ -21,7 +21,11 @@ class CocoPanoptic(Coco):
 
     default_config = Coco.default_config.copy()
     # extra switch to enable panoptic loading
-    default_config.update({'load_panoptic': False})
+    default_config.update({
+        'load_panoptic': False,
+        # when true, use grayscale CS-34 masks instead of RGB panoptic labels
+        'use_cs34_masks': False,
+    })
 
     def __init__(self, export=False, transform=None, task='train', **config):
         # turn off instance masks when panoptic segmentation is requested
@@ -32,10 +36,21 @@ class CocoPanoptic(Coco):
         super().__init__(export=export, transform=transform, task=task, **config)
 
         self.panoptic_segments = {}
-        self.panoptic_root = None
+        self.panoptic_root = None  # original COCO panoptic RGB masks
+        self.cs34_root = None  # grayscale CS-34 masks
 
         if self.config.get('load_panoptic', False):
-            # panoptic annotations json
+            # allow explicit request for CS-34 grayscale masks via config
+            if self.config.get('use_cs34_masks', False):
+                cs34_root = Path(DATA_PATH, 'COCO', f'panoptic_cs34_{task}2017')
+                if cs34_root.exists():
+                    self.cs34_root = cs34_root
+                    self.num_segmentation_classes = self.config.get('num_segmentation_classes', 34)
+                else:
+                    logging.warning('Requested CS-34 masks but folder not found: %s', cs34_root)
+                return
+
+            # otherwise try standard COCO panoptic setup first
             ann_file = Path(DATA_PATH, 'COCO/annotations', f'panoptic_{task}2017.json')
             if ann_file.exists():
                 with open(ann_file, 'r') as f:
@@ -47,45 +62,72 @@ class CocoPanoptic(Coco):
                     seg_map = {seg['id']: seg['category_id'] for seg in ann['segments_info']}
                     self.panoptic_segments[ann['file_name']] = seg_map
             else:
-                logging.warning('Panoptic annotation file not found: %s', ann_file)
+                # fallback: look for CS-34 masks without JSON annotations
+                cs34_root = Path(DATA_PATH, 'COCO', f'panoptic_cs34_{task}2017')
+                if cs34_root.exists():
+                    self.cs34_root = cs34_root
+                    self.num_segmentation_classes = self.config.get('num_segmentation_classes', 34)
+                else:
+                    logging.warning('Panoptic annotation file not found: %s', ann_file)
 
     def __getitem__(self, index):
         # get sample from base class
         input_dict = super().__getitem__(index)
 
-        if self.config.get('load_panoptic', False) and self.panoptic_root is not None:
+        if self.config.get('load_panoptic', False):
             sample = self.samples[index]
             image_name = Path(sample['image']).with_suffix('.png').name
-            pan_path = self.panoptic_root / image_name
             H, W = input_dict['image'].shape[-2:]
-            seg_mask = torch.zeros((H, W), dtype=torch.long)  # fallback mask prevents KeyError
-            if pan_path.exists():
-                pan_img = cv2.imread(str(pan_path), cv2.IMREAD_COLOR)
-                # convert BGR image returned by OpenCV to RGB for rgb2id
-                pan_img = cv2.cvtColor(pan_img, cv2.COLOR_BGR2RGB)
-                seg_ids = rgb2id(pan_img)
-                cat_map = np.zeros_like(seg_ids, dtype=np.int32)
-                mapping = self.panoptic_segments.get(image_name, {})
-                for seg_id, cat_id in mapping.items():
-                    cat_map[seg_ids == seg_id] = cat_id
-                cat_map = cv2.resize(cat_map, (W, H), interpolation=cv2.INTER_NEAREST)
-                num_cls = self.config.get('num_segmentation_classes', 0)
-                if num_cls > 0:
-                    max_val = int(cat_map.max())
-                    if max_val >= num_cls:
-                        logging.warning(
-                            "Segmentation label %d exceeds num_segmentation_classes=%d; clipping",
-                            max_val,
-                            num_cls,
-                        )
-                    cat_map = np.clip(cat_map, 0, num_cls - 1)
 
-                seg_mask = torch.tensor(cat_map, dtype=torch.long)
+            if self.panoptic_root is not None:
+                pan_path = self.panoptic_root / image_name
+                seg_mask = torch.zeros((H, W), dtype=torch.long)
+                if pan_path.exists():
+                    pan_img = cv2.imread(str(pan_path), cv2.IMREAD_COLOR)
+                    pan_img = cv2.cvtColor(pan_img, cv2.COLOR_BGR2RGB)
+                    seg_ids = rgb2id(pan_img)
+                    cat_map = np.zeros_like(seg_ids, dtype=np.int32)
+                    mapping = self.panoptic_segments.get(image_name, {})
+                    for seg_id, cat_id in mapping.items():
+                        cat_map[seg_ids == seg_id] = cat_id
+                    cat_map = cv2.resize(cat_map, (W, H), interpolation=cv2.INTER_NEAREST)
+                    num_cls = self.config.get('num_segmentation_classes', 0)
+                    if num_cls > 0:
+                        max_val = int(cat_map.max())
+                        if max_val >= num_cls:
+                            logging.warning(
+                                "Segmentation label %d exceeds num_segmentation_classes=%d; clipping",
+                                max_val,
+                                num_cls,
+                            )
+                        cat_map = np.clip(cat_map, 0, num_cls - 1)
+
+                    seg_mask = torch.tensor(cat_map, dtype=torch.long)
+                else:
+                    logging.warning('Missing panoptic file for image %s', image_name)
+
+            elif self.cs34_root is not None:
+                pan_path = self.cs34_root / image_name
+                seg_mask = torch.zeros((H, W), dtype=torch.long)
+                if pan_path.exists():
+                    seg_img = cv2.imread(str(pan_path), cv2.IMREAD_GRAYSCALE)
+                    seg_img = cv2.resize(seg_img, (W, H), interpolation=cv2.INTER_NEAREST)
+                    seg_mask = torch.tensor(seg_img, dtype=torch.long)
+                    num_cls = self.config.get('num_segmentation_classes', 0)
+                    if num_cls > 0:
+                        max_val = int(seg_mask.max())
+                        if max_val >= num_cls:
+                            logging.warning(
+                                "Segmentation label %d exceeds num_segmentation_classes=%d; clipping",
+                                max_val,
+                                num_cls,
+                            )
+                            seg_mask = torch.clamp(seg_mask, 0, num_cls - 1)
+                else:
+                    logging.warning('Missing panoptic file for image %s', image_name)
                 
             else:
-                # skip mask if panoptic file missing
-                logging.warning('Missing panoptic file for image %s', image_name)
-                # seg_mask stays all zeros so later code can access segmentation_mask safely
+                seg_mask = torch.zeros((H, W), dtype=torch.long)
 
             input_dict['segmentation_mask'] = seg_mask
 


### PR DESCRIPTION
## Summary
- allow training with CS-34 grayscale masks via new `use_cs34_masks` option
- document the option in the README
- update the sample COCO config to enable CS-34 masks

The new option lets users explicitly choose the 34-class panoptic masks in `panoptic_cs34_*` folders instead of standard panoptic labels. When enabled, `CocoPanoptic` loads these grayscale masks and ignores the JSON annotations.

## Testing
- `python -m py_compile datasets/CocoPanoptic.py`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685ed4f456448329aabec589f36f2105