### PR TITLE
Add comments and clarify pretrained usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,18 +108,21 @@ datasets/ ($DATA_DIR)
 ```
 - If the dataset is stored elsewhere, update `DATA_PATH` in `settings.py`.
 
-Example commands using `superpoint_cityscapes_train.yaml`:
+Example commands using the Cityscapes configs:
 
 ```bash
 # training
-python train4.py train_joint configs/superpoint_cityscapes_train.yaml superpoint_cityscapes --eval
+python train4.py train_joint configs/superpoint_cityscapes_finetune.yaml superpoint_cityscapes --eval
 
 # export predictions (including segmentation masks)
-python export.py export_descriptor configs/superpoint_cityscapes_train.yaml superpoint_cityscapes_val --export-segmentation
+python export.py export_descriptor configs/superpoint_cityscapes_export.yaml cityscapes_export --export-segmentation
 
 # evaluate exported segmentation
-python evaluation.py logs/superpoint_cityscapes_val/predictions --evaluate-segmentation
+python evaluation.py logs/cityscapes_export/predictions --evaluate-segmentation
 ```
+
+Both configs load a checkpoint via their `pretrained` option. Update this path
+to point at the model you wish to fine-tune or evaluate.
 
 Predicted segmentation masks can also be exported by adding
 `--export-segmentation` to other export commands and evaluated using

--- a/configs/superpoint_cityscapes_export.yaml
+++ b/configs/superpoint_cityscapes_export.yaml
@@ -1,0 +1,58 @@
+# Configuration for exporting SuperPoint predictions on the Cityscapes dataset
+# This loads the fine-tuned model and writes predictions for the "val" split
+
+data:
+    name: 'Cityscapes'
+    dataset: 'Cityscapes'            # dataset name
+    alteration: 'all'                # 'all' 'i' 'v'
+    export_folder: 'val'             # choose split
+    root: 'datasets/Cityscapes'      # path to Cityscapes images
+    segmentation_labels: 'datasets/Cityscapes/gtFine'  # segmentation masks
+    preprocessing:
+        resize: [512, 1024]
+    gaussian_label:
+        enable: false
+        sigma: 1.
+    augmentation:
+        photometric:
+            enable: false
+    homography_adaptation:
+        enable: true
+        num: 100
+        aggregation: 'sum'
+        filter_counts: 0
+        homographies:
+            params:
+                translation: true
+                rotation: true
+                scaling: true
+                perspective: true
+                scaling_amplitude: 0.2
+                perspective_amplitude_x: 0.2
+                perspective_amplitude_y: 0.2
+                allow_artifacts: true
+                patch_ratio: 0.85
+
+training:
+    workers_test: 2
+
+# model used for exporting
+front_end_model: 'Val_model_heatmap'  # 'Train_model_frontend'
+
+model:
+    name: 'SuperPointNet_gauss2'
+    params: {}
+    batch_size: 1
+    eval_batch_size: 1
+    detection_threshold: 0.015
+    nms: 4
+    top_k: 600
+    subpixel:
+        enable: true
+
+# Path to the fine-tuned checkpoint to load before export
+pretrained: 'logs/superpoint_cityscapes/checkpoints/superPointNet_best.pth.tar'
+
+# evaluate only once
+eval_iter: 100
+


### PR DESCRIPTION
## Summary
- explain that configs rely on the `pretrained` field in README
- expand `superpoint_cityscapes_export.yaml` with dataset metadata and comments