### PR TITLE
Add Cityscapes warped pair support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ python evaluation.py logs/cityscapes_export/predictions --evaluate-segmentation
 Both configs load a checkpoint via their `pretrained` option. Update this path
 to point at the model you wish to fine-tune or evaluate.
 
+When `warped_pair.enable` is set to true in `superpoint_cityscapes_export.yaml`,
+the Cityscapes loader also returns `warped_image` and its corresponding
+`homography` so descriptor metrics can be exported like on COCO or HPatches.
+
 Predicted segmentation masks can also be exported by adding
 `--export-segmentation` to other export commands and evaluated using
 `evaluation.py --evaluate-segmentation`.

--- a/configs/superpoint_cityscapes_export.yaml
+++ b/configs/superpoint_cityscapes_export.yaml
@@ -10,6 +10,20 @@ data:
     segmentation_labels: 'datasets/Cityscapes/gtFine'  # segmentation masks
     preprocessing:
         resize: [240, 320] #[512, 1024]
+    warped_pair:
+        enable: true
+        params:
+            translation: true
+            rotation: true
+            scaling: true
+            perspective: true
+            scaling_amplitude: 0.2
+            perspective_amplitude_x: 0.2
+            perspective_amplitude_y: 0.2
+            patch_ratio: 0.85
+            max_angle: 1.57
+            allow_artifacts: true
+        valid_border_margin: 3
 
 training:
     workers_test: 16


### PR DESCRIPTION
## Summary
- extend `Cityscapes` loader with optional homography warping
- enable `warped_pair` in the Cityscapes export config
- document how to use this feature in README