### PR TITLE
Implement Cityscapes 4-category mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ python export.py export_descriptor configs/superpoint_cityscapes_export.yaml cit
 python evaluation.py logs/cityscapes_export/predictions --evaluate-segmentation
 ```
 
+To visualize the 4-category mapping, pass `--category-file utils/cs4_categories.json`
+to `evaluation.py`.
+
 Both configs load a checkpoint via their `pretrained` option. Update this path
 to point at the model you wish to fine-tune or evaluate.
 

--- a/configs/superpoint_cityscapes_export.yaml
+++ b/configs/superpoint_cityscapes_export.yaml
@@ -10,6 +10,7 @@ data:
     segmentation_labels: 'datasets/Cityscapes/gtFine'  # segmentation masks
     preprocessing:
         resize: [240, 320] #[512, 1024]
+    reduce_to_4_categories: true
     warped_pair:
         enable: true
         params:
@@ -35,7 +36,7 @@ model:
     name: 'SuperPointNet_gauss2'
     params: {}
     lambda_segmentation: 1.0
-    num_segmentation_classes: 34
+    num_segmentation_classes: 4
 
     # learning_rate: 0.0001 # 0.0001
     detection_threshold: 0.015 # 0.015

--- a/configs/superpoint_cityscapes_finetune.yaml
+++ b/configs/superpoint_cityscapes_finetune.yaml
@@ -1,5 +1,5 @@
 # Configuration for training SuperPoint on the Cityscapes dataset
-# Includes segmentation masks with 34 classes
+# Segmentation labels can be reduced to 4 coarse categories
 
 data:
     dataset: 'Cityscapes'
@@ -7,7 +7,8 @@ data:
     segmentation_labels: 'datasets/Cityscapes/gtFine'  # segmentation masks
     cache_in_memory: false
     load_segmentation: true
-    num_segmentation_classes: 34
+    reduce_to_4_categories: true
+    num_segmentation_classes: 4
     preprocessing:
         resize: [240, 320] #[512, 1024]  # images are downsampled for training
     augmentation:
@@ -60,7 +61,7 @@ model:
     detection_threshold: 0.015
     lambda_loss: 1
     lambda_segmentation: 1.0
-    num_segmentation_classes: 34
+    num_segmentation_classes: 4
     nms: 4
     dense_loss:
         enable: false

--- a/datasets/Cityscapes.py
+++ b/datasets/Cityscapes.py
@@ -13,6 +13,17 @@ from settings import DATA_PATH
 from utils.tools import dict_update
 
 
+# mapping from 34 Cityscapes labelIds to 4 broad categories
+# 0 -> Static Structure, 1 -> Flat Surfaces,
+# 2 -> Dynamic Objects, 3 -> Unstable/Ambiguous
+CS34_TO_4 = {
+    11: 0, 12: 0, 13: 0, 14: 0, 15: 0, 16: 0, 17: 0, 18: 0, 19: 0, 20: 0,
+    7: 1, 8: 1, 9: 1, 10: 1, 22: 1,
+    24: 2, 25: 2, 26: 2, 27: 2, 28: 2, 29: 2, 30: 2, 31: 2, 32: 2, 33: 2,
+    21: 3, 23: 3, 6: 3, 5: 3, 4: 3, 0: 3, 1: 3, 2: 3, 3: 3,
+}
+
+
 class Cityscapes(data.Dataset):
     """Dataset loader for Cityscapes images and semantic labels.
 
@@ -25,6 +36,8 @@ class Cityscapes(data.Dataset):
         'labels': None,
         'segmentation_labels': None,
         'num_segmentation_classes': 34,
+        # optionally map the 34 labelIds to 4 coarse categories
+        'reduce_to_4_categories': False,
         'cache_in_memory': False,
         'validation_size': 100,
         'truncate': None,
@@ -95,6 +108,14 @@ class Cityscapes(data.Dataset):
             else:
                 logging.warning('Missing segmentation label file: %s', mask_path)
                 seg_mask = torch.zeros((H, W), dtype=torch.long)
+            if self.config.get('reduce_to_4_categories', False):
+                # convert CS-34 labels to the 4-category scheme
+                mask_np = seg_mask.numpy()
+                mapped = np.full_like(mask_np, 3)
+                for k, v in CS34_TO_4.items():
+                    mapped[mask_np == k] = v
+                seg_mask = torch.from_numpy(mapped)
+
             # semantic segmentation mask with dtype long and shape (H, W)
             output['segmentation_mask'] = seg_mask
 

--- a/utils/cs4_categories.json
+++ b/utils/cs4_categories.json
@@ -1,0 +1,6 @@
+[
+    {"id": 0, "name": "static structure", "color": [0, 0, 255]},
+    {"id": 1, "name": "flat surfaces", "color": [0, 255, 0]},
+    {"id": 2, "name": "dynamic objects", "color": [255, 0, 0]},
+    {"id": 3, "name": "unstable/ambiguous", "color": [255, 255, 255]}
+]


### PR DESCRIPTION
## Summary
- add CS34_TO_4 mapping in `datasets/Cityscapes.py`
- support new `reduce_to_4_categories` option
- update Cityscapes configs to enable the 4 category mode
- provide helper colors in `utils/cs4_categories.json`
- document evaluation usage in README

## Testing
- `python -m py_compile datasets/Cityscapes.py`

------
https://chatgpt.com/codex/tasks/task_e_685f1cf6b0c48329a8ab7a90e7653d7a