### PR TITLE
Add segmentation overlay to TensorBoard

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ batch size is one.
     - Currently Support training on 'COCO' dataset (original paper), 'KITTI' dataset.
 - Tensorboard:
     - log files is saved under 'runs/<\export_task>/...'
+    - `seg_overlay` shows predicted segmentation masks blended with the input image
     
 `tensorboard --logdir=./runs/ [--host | static_ip_address] [--port | 6008]`
 


### PR DESCRIPTION
## Summary
- visualize segmentation predictions by overlaying masks onto input images during training
- expose segmentation overlays via `tb_images_dict`
- document the new `seg_overlay` image group in README