### PR TITLE
Refactor SummaryWriter setup

### DIFF
--- a/export.py
+++ b/export.py
@@ -17,7 +17,6 @@ from pathlib import Path
 import numpy as np
 from imageio import imread
 from tqdm import tqdm
-from torch.utils.tensorboard import SummaryWriter
 
 ## torch
 import torch
@@ -35,7 +34,7 @@ from utils.utils import (
     load_checkpoint,
     save_path_formatter,
 )
-from utils.utils import getWriterPath, flattenDetection
+from utils.utils import flattenDetection, create_writer
 from utils.loader import dataLoader, modelLoader, pretrainedLoader
 from utils.utils import inv_warp_image_batch
 from models.model_wrap import SuperPointFrontend_torch, PointTracker
@@ -89,7 +88,8 @@ def export_descriptor(config, output_dir, args):
     logging.info("train on device: %s", device)
     with open(os.path.join(output_dir, "config.yml"), "w") as f:
         yaml.dump(config, f, default_flow_style=False)
-    writer = SummaryWriter(getWriterPath(task=args.command, date=True))
+    # centralize SummaryWriter creation through helper
+    writer = create_writer(task=args.command)
     save_path = get_save_path(output_dir)
     save_output = save_path / "../predictions"
     os.makedirs(save_output, exist_ok=True)
@@ -242,9 +242,8 @@ def export_detector_homoAdapt_gpu(config, output_dir, args):
     logging.info("train on device: %s", device)
     with open(os.path.join(output_dir, "config.yml"), "w") as f:
         yaml.dump(config, f, default_flow_style=False)
-    writer = SummaryWriter(
-        getWriterPath(task=args.command, exper_name=args.exper_name, date=True)
-    )
+    # use helper to create writer with experiment name
+    writer = create_writer(task=args.command, exper_name=args.exper_name)
 
     ## parameters
     nms_dist = config["model"]["nms"]  # 4

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -901,6 +901,18 @@ def getWriterPath(task='train', exper_name='', date=True):
         str_date_time = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     return prefix + task + '/' + exper_name + str_date_time
 
+# helper to create SummaryWriter at the desired path
+def create_writer(task='train', exper_name=''):
+    """Utility wrapper combining :func:`getWriterPath` and ``SummaryWriter``.
+
+    The writer logs to ``runs/<task>/<exper_name>_<date>`` similar to the
+    original code but centralizes the creation logic.
+    """
+    from torch.utils.tensorboard import SummaryWriter
+
+    writer_path = getWriterPath(task=task, exper_name=exper_name, date=True)
+    return SummaryWriter(writer_path)
+
 def crop_or_pad_choice(in_num_points, out_num_points, shuffle=False):
     # Adapted from https://github.com/haosulab/frustum_pointnet/blob/635c938f18b9ec1de2de717491fb217df84d2d93/fpointnet/data/datasets/utils.py
     """Crop or pad point cloud to a fixed number; return the indexes


### PR DESCRIPTION
## Summary
- add `create_writer` helper wrapping `getWriterPath` and `SummaryWriter`
- use the helper in `export.py`
- remove direct SummaryWriter imports