### PR TITLE
Remove unused SummaryWriter import

### DIFF
--- a/utils/draw.py
+++ b/utils/draw.py
@@ -11,9 +11,9 @@ import logging
 from pathlib import Path
 
 import numpy as np
+# Removed unused TensorBoard writer import
 from tqdm import tqdm
 
-from torch.utils.tensorboard import SummaryWriter
 import cv2
 import matplotlib.pyplot as plt
 


### PR DESCRIPTION
## Summary
- strip the `SummaryWriter` import from `utils/draw.py`
- add a note explaining the removal