### PR TITLE
Fix export device mismatch

### DIFF
--- a/export.py
+++ b/export.py
@@ -242,7 +242,8 @@ def export_descriptor(config, output_dir, args):
             H, W = img_np.shape
             homography = homography.to(device)
             uv_b, mask = filter_points(
-                warp_points(uv_a.to(device), homography),
+                # ensure warp computation happens on the same device
+                warp_points(uv_a.to(device), homography, device=device),
                 torch.tensor([W, H], device=device),
                 return_mask=True,
             )
@@ -550,7 +551,8 @@ def export_detector_homoAdapt_gpu(config, output_dir, args):
             homography = homography.to(device)
             # warp keypoints with the provided homography
             uv_b, mask = filter_points(
-                warp_points(uv_a.to(device), homography),
+                # ensure warp computation happens on the same device
+                warp_points(uv_a.to(device), homography, device=device),
                 torch.tensor([W, H], device=device),
                 return_mask=True,
             )


### PR DESCRIPTION
## Summary
- avoid mixing cpu and gpu tensors in `warp_points`
- pass device explicitly when exporting keypoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68693e85ffa083299edb3db99e103311