### PR TITLE
Fix homography dimension bug

### DIFF
--- a/export.py
+++ b/export.py
@@ -239,6 +239,9 @@ def export_descriptor(config, output_dir, args):
         uv_a = torch.from_numpy(pts[:, :2]).float()
         homography = sample.get("homography")
         if homography is not None:
+            # dataloader wraps tensors with an extra batch dimension, remove it
+            if homography.ndim == 3:
+                homography = homography.squeeze(0)
             H, W = img_np.shape
             homography = homography.to(device)
             uv_b, mask = filter_points(
@@ -547,6 +550,9 @@ def export_detector_homoAdapt_gpu(config, output_dir, args):
         uv_a = torch.from_numpy(pts[:, :2]).float()
         homography = sample.get("homography")
         if homography is not None:
+            # remove potential batch dimension added by dataloader
+            if homography.ndim == 3:
+                homography = homography.squeeze(0)
             H, W = img_2D.shape
             homography = homography.to(device)
             # warp keypoints with the provided homography

--- a/utils/draw.py
+++ b/utils/draw.py
@@ -75,6 +75,11 @@ def draw_keypoints(img, corners, color=(0, 255, 0), radius=3, s=3):
         numpy [H, W]
     '''
     img = np.repeat(cv2.resize(img, None, fx=s, fy=s)[..., np.newaxis], 3, -1)
+
+    # Return early if no keypoints to draw
+    if corners is None or len(corners) == 0:
+        return img
+
     for c in np.stack(corners).T:
         # cv2.circle(img, tuple(s * np.flip(c, 0)), radius, color, thickness=-1)
         cv2.circle(img, tuple((s * c[:2]).astype(int)), radius, color, thickness=-1)


### PR DESCRIPTION
## Summary
- handle batch dimension on homographies when exporting descriptors
- safely draw keypoints when there are no valid points