### PR TITLE
Add option to freeze detector during segmentation finetune

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ to `evaluation.py`.
 
 Both configs load a checkpoint via their `pretrained` option. Update this path
 to point at the model you wish to fine-tune or evaluate.
+Set `model.freeze_detector: true` in `superpoint_cityscapes_finetune.yaml` to
+freeze the keypoint detector and only train the segmentation head during
+fine-tuning.
 
 When `warped_pair.enable` is set to true in `superpoint_cityscapes_export.yaml`,
 the Cityscapes loader also returns `warped_image` and its corresponding

--- a/configs/superpoint_cityscapes_finetune.yaml
+++ b/configs/superpoint_cityscapes_finetune.yaml
@@ -74,6 +74,7 @@ model:
     lambda_segmentation: 1.0
     num_segmentation_classes: 4
     compute_miou: true  # log mIoU for each batch
+    freeze_detector: true  # keep keypoint detector weights fixed
     nms: 3
     dense_loss:
         enable: false


### PR DESCRIPTION
## Summary
- allow freezing the SuperPoint detector and descriptor when fine‑tuning
- filter the optimizer parameters so only trainable layers update
- document the `model.freeze_detector` flag and enable it in the Cityscapes finetune config