### PR TITLE
Add segmentation-only finetune option

### DIFF
--- a/Train_model_heatmap.py
+++ b/Train_model_heatmap.py
@@ -67,6 +67,7 @@ class Train_model_heatmap(Train_model_frontend):
         "model": {
             "subpixel": {"enable": False},
             "compute_miou": False,
+            "freeze_det_desc": False,  # freeze detector/descriptor heads
         },
         "data": {"gaussian_label": {"enable": False}},
     }
@@ -203,6 +204,9 @@ class Train_model_heatmap(Train_model_frontend):
         mask_2D = sample.get("valid_mask")
 
         has_kpt_labels = labels_2D is not None
+        if self.config["model"].get("freeze_det_desc", False):
+            # ignore keypoint labels when detector/descriptor heads are frozen
+            has_kpt_labels = False
 
         # enable warping when the dataset provides a warped pair. Some datasets
         # use the key 'warped_image' instead of 'warped_img'.

--- a/configs/superpoint_cityscapes_finetune.yaml
+++ b/configs/superpoint_cityscapes_finetune.yaml
@@ -74,6 +74,7 @@ model:
     lambda_segmentation: 1.0
     num_segmentation_classes: 4
     compute_miou: true  # log mIoU for each batch
+    freeze_det_desc: true  # only finetune segmentation head
     nms: 3
     dense_loss:
         enable: false

--- a/configs/superpoint_cityscapes_finetune.yaml
+++ b/configs/superpoint_cityscapes_finetune.yaml
@@ -18,7 +18,7 @@ data:
         resize: [240, 320] #[512, 1024]  # images are downsampled for training
     augmentation:
         photometric:
-            enable: true
+            enable: false  # disable photometric augmentation during finetuning
             primitives: [
                 'random_brightness', 'random_contrast', 'additive_speckle_noise',
                 'additive_gaussian_noise', 'additive_shade', 'motion_blur']
@@ -32,7 +32,7 @@ data:
                     kernel_size_range: [100, 150]
                 motion_blur: {max_kernel_size: 3}
         homographic:
-            enable: true
+            enable: false  # no homographic augmentation
             num_homographies: 10       # samples per image for aggregation
             max_angle: 0.005             # in radians (~10°)
             translate: 0.005              # relative to image size
@@ -40,12 +40,12 @@ data:
             perspective: 0.005
             allow_artifacts: false
     warped_pair:
-        enable: true
+        enable: false  # do not generate warped pairs
         params:
-            translation: true
-            rotation: true
-            scaling: true
-            perspective: true
+            translation: false  # disable all geometric transforms
+            rotation: false
+            scaling: false
+            perspective: false
             scaling_amplitude: 0.005  # reduced for gentler warp
             perspective_amplitude_x: 0.005  # reduced for gentler warp
             perspective_amplitude_y: 0.005  # reduced for gentler warp


### PR DESCRIPTION
## Summary
- add `freeze_det_desc` option to default configs
- freeze detector/descriptor layers in `loadModel`
- ignore keypoint labels when the option is enabled
- enable this option for Cityscapes finetuning config