### PR TITLE
Fix multi-channel input support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ datasets/ ($DATA_DIR)
 - Images remain in RGB and are normalized per channel. The exact values are:
   - `CITYSCAPES_MEAN=(0.28689554, 0.32513303, 0.28389177)`
   - `CITYSCAPES_STD=(0.18696375, 0.19017339, 0.18720214)`
+  - When training on these RGB images, set `model.params.input_channels` to
+    `3` as done in `configs/superpoint_cityscapes_finetune.yaml`.
 
 Example commands using the Cityscapes configs:
 

--- a/configs/magicpoint_cityscape_export.yaml
+++ b/configs/magicpoint_cityscape_export.yaml
@@ -38,8 +38,8 @@ training:
 model:
     # name: 'SuperPointNet' # 'SuperPointNet_gauss2'
     name: 'SuperPointNet_gauss2' # 'SuperPointNet_gauss2'
-    params: {
-    }    
+    # instruct the network to process RGB images
+    params: {input_channels: 3}
     batch_size: 8
     eval_batch_size: 8
     detection_threshold: 0.015 # 0.015

--- a/configs/superpoint_cityscapes_export.yaml
+++ b/configs/superpoint_cityscapes_export.yaml
@@ -35,7 +35,9 @@ front_end_model: 'Val_model_heatmap'  # 'Train_model_frontend'
 
 model:
     name: 'SuperPointNet_gauss2'
-    params: {}
+    # match the RGB inputs of the Cityscapes dataset
+    params:
+        input_channels: 3
     lambda_segmentation: 1.0
     num_segmentation_classes: 4
 

--- a/configs/superpoint_cityscapes_finetune.yaml
+++ b/configs/superpoint_cityscapes_finetune.yaml
@@ -56,7 +56,9 @@ training:
 
 model:
     name: 'SuperPointNet_gauss2'
-    params: {}
+    # use three-channel inputs when training on RGB datasets
+    params:
+        input_channels: 3
     detector_loss:
         loss_type: 'softmax'
 

--- a/models/SuperPointNet_gauss2.py
+++ b/models/SuperPointNet_gauss2.py
@@ -50,11 +50,13 @@ class ASPP(nn.Module):
 
 class SuperPointNet_gauss2(torch.nn.Module):
     """ Pytorch definition of SuperPoint Network. """
-    def __init__(self, subpixel_channel=1, num_classes=1):
+    def __init__(self, subpixel_channel=1, num_classes=1, input_channels=1):
         super(SuperPointNet_gauss2, self).__init__()
         c1, c2, c3, c4, c5, d1 = 64, 64, 128, 128, 256, 256
         det_h = 65
-        self.inc = inconv(1, c1)
+        # allow networks trained on RGB images by exposing the number of
+        # input channels; defaults to 1 for backwards compatibility
+        self.inc = inconv(input_channels, c1)
         self.down1 = down(c1, c2)
         self.down2 = down(c2, c3)
         self.down3 = down(c3, c4)
@@ -92,7 +94,8 @@ class SuperPointNet_gauss2(torch.nn.Module):
         """ Forward pass that jointly computes unprocessed point and descriptor
         tensors.
         Input
-          x: Image pytorch tensor shaped N x 1 x patch_size x patch_size.
+          x: Image pytorch tensor shaped N x C x patch_size x patch_size,
+            where C matches ``input_channels``.
         Output
           semi: Output point pytorch tensor shaped N x 65 x H/8 x W/8.
           desc: Output descriptor pytorch tensor shaped N x 256 x H/8 x W/8.


### PR DESCRIPTION
## Summary
- allow SuperPointNet_gauss2 to accept configurable input channels
- update cityscapes configs to use `input_channels: 3`
- document new option in README