### PR TITLE
Enable Euler-angle based warping for Cityscapes

### DIFF
--- a/configs/superpoint_cityscapes_export.yaml
+++ b/configs/superpoint_cityscapes_export.yaml
@@ -19,9 +19,9 @@ data:
             rotation: true
             scaling: true
             perspective: true
-            scaling_amplitude: 0.01
-            perspective_amplitude_x: 0.005
-            perspective_amplitude_y: 0.005
+            yaw_range: 1.0
+            pitch_range: 1.0
+            roll_range: 1.0
             patch_ratio: 0.9
             allow_artifacts: false
         valid_border_margin: 3

--- a/configs/superpoint_cityscapes_finetune.yaml
+++ b/configs/superpoint_cityscapes_finetune.yaml
@@ -40,9 +40,9 @@ data:
             rotation: true
             scaling: true
             perspective: true
-            scaling_amplitude: 0.15  # reduced for gentler warp
-            perspective_amplitude_x: 0.1  # reduced for gentler warp
-            perspective_amplitude_y: 0.1  # reduced for gentler warp
+            yaw_range: 2.0
+            pitch_range: 2.0
+            roll_range: 2.0
             patch_ratio: 0.85  # wider valid area
             max_angle: 1.0  # ~57 degrees
             allow_artifacts: true


### PR DESCRIPTION
## Summary
- compute camera-to-vehicle & inverse extrinsics in Cityscapes loader
- cache intrinsics and inverse intrinsics for each sample
- implement small yaw/pitch/roll perturbations for warped pairs and augmentation
- update configs to use new `*_range` parameters