### PR TITLE
Add debug dumping for Cityscapes warped pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ along with `valid_mask`, `homographies` and `inv_homographies` for GPU-based
 homography adaptation export.
 Each sample now also contains a `scene_name` entry (the city identifier) so that
 the export script can organise predictions in subfolders like it does for KITTI.
+Setting `debug_dump: true` in the dataset configuration saves the warped image
+and its valid mask to `logs/debug_warped/<split>/`.
 
 Exporting MagicPoint on Cityscapes now also writes TensorBoard summaries.
 Open TensorBoard in `runs/export_detector_homoAdapt/` to browse keypoint

--- a/configs/magicpoint_cityscape_export.yaml
+++ b/configs/magicpoint_cityscape_export.yaml
@@ -2,8 +2,9 @@ data:
     dataset: 'Cityscapes'  # 'coco' 'hpatches'
     export_folder: 'val' # train, val
     preprocessing:
-        resize: [240, 320] 
-        # resize: [480, 640] 
+        resize: [240, 320]
+        # resize: [480, 640]
+    debug_dump: false
     gaussian_label:
         enable: false # false
         sigma: 1.

--- a/configs/superpoint_cityscapes_export.yaml
+++ b/configs/superpoint_cityscapes_export.yaml
@@ -11,6 +11,7 @@ data:
     preprocessing:
         resize: [240, 320] #[512, 1024]
     reduce_to_4_categories: true
+    debug_dump: false
     # generate a warped image pair similar to the training setup
     warped_pair:
         enable: true

--- a/configs/superpoint_cityscapes_finetune.yaml
+++ b/configs/superpoint_cityscapes_finetune.yaml
@@ -9,6 +9,7 @@ data:
     cache_in_memory: false
     load_segmentation: true
     reduce_to_4_categories: true
+    debug_dump: false
     num_segmentation_classes: 4
     gaussian_label:
         enable: true


### PR DESCRIPTION
## Summary
- add `debug_dump` option to Cityscapes dataset
- export warped pair dumps with keypoints when enabled
- document new flag in Cityscapes configs
- note dump location in README