### PR TITLE
Fix warped image batch dimension

### DIFF
--- a/datasets/Cityscapes.py
+++ b/datasets/Cityscapes.py
@@ -371,7 +371,8 @@ class Cityscapes(data.Dataset):
                 image_tensor.unsqueeze(0),
                 torch.tensor(homo_inv, dtype=torch.float32),
             ).squeeze(0)
-            output['warped_image'] = warped.unsqueeze(0)
+            # keep 3D tensor so DataLoader batching results in 4-D inputs
+            output['warped_image'] = warped
             output['warped_img'] = output['warped_image']
             H_mat = torch.tensor(homography, dtype=torch.float32)
             H_inv_mat = torch.tensor(homo_inv, dtype=torch.float32)


### PR DESCRIPTION
## Summary
- avoid unsqueezed tensors when returning `warped_image` in the Cityscapes dataset

The export script failed with a 5-D tensor error because `Cityscapes.__getitem__`
added an extra dimension to `warped_image`. When the `DataLoader` batched this
sample the input shape became `[1, 1, 3, H, W]`, which `conv2d` rejected.
`warped_image` now stays 3-D so batching results in the expected 4‑D tensor.