### PR TITLE
Fix HWC to CHW conversions for TensorBoard

### DIFF
--- a/Train_model_frontend.py
+++ b/Train_model_frontend.py
@@ -736,7 +736,8 @@ class Train_model_frontend(object):
                 if img.ndim == 3:
                     # handle both CHW and HWC layout
                     if img.shape[-1] <= 4:  # HWC with 1-4 channels
-                        img = img[..., :3].transpose(2, 0, 1)
+                        # TensorBoard expects channel-first tensors
+                        img = img[..., :3].permute(2, 0, 1)
                     else:  # assume CHW format
                         img = img[:3]
                 self.writer.add_image(

--- a/Train_model_subpixel.py
+++ b/Train_model_subpixel.py
@@ -192,7 +192,8 @@ class Train_model_subpixel(Train_model_frontend):
         for element in list(tb_imgs):
             for idx in range(tb_imgs[element].shape[0]):
                 if idx >= max_img: break
-                self.writer.add_image(task + '-' + element + '/%d'%idx, 
+                # tb expects channel-first tensors
+                self.writer.add_image(task + '-' + element + '/%d'%idx,
                     tb_imgs[element][idx,...], self.n_iter)
 
     def tb_hist_dict(self, task, tb_dict):


### PR DESCRIPTION
## Summary
- convert images to channel-first layout with `permute` instead of `transpose`
- clarify TensorBoard expects channel-first tensors