### PR TITLE
Fix batch dimension handling when exporting

### DIFF
--- a/export.py
+++ b/export.py
@@ -455,9 +455,11 @@ def export_detector_homoAdapt_gpu(config, output_dir, args):
     ## loop through all images
     for i, sample in tqdm(enumerate(test_loader)):
         img, mask_2D = sample["image"], sample["valid_mask"]
-        img = img.transpose(0, 1)
+        # the dataset already outputs a batch of warped images (N, C, H, W).
+        # DataLoader wrapping adds a leading dimension which we drop here.
+        img = img.squeeze(0)
         img_2D = sample["image_2D"].numpy().squeeze()
-        mask_2D = mask_2D.transpose(0, 1)
+        mask_2D = mask_2D.squeeze(0)
 
         inv_homographies, homographies = (
             sample["homographies"],


### PR DESCRIPTION
## Summary
- drop DataLoader batch dimension instead of transposing in `export.py`
- clarify dataset output shape with inline comments