### PR TITLE
Enable grayscale Cityscapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,12 +107,12 @@ datasets/ ($DATA_DIR)
         |-- val
         `-- test
 ```
-- If the dataset is stored elsewhere, update `DATA_PATH` in `settings.py`.
-- Images remain in RGB and are normalized per channel. The exact values are:
-  - `CITYSCAPES_MEAN=(0.28689554, 0.32513303, 0.28389177)`
-  - `CITYSCAPES_STD=(0.18696375, 0.19017339, 0.18720214)`
-  - When training on these RGB images, set `model.params.input_channels` to
-    `3` as done in `configs/superpoint_cityscapes_finetune.yaml`.
+If the dataset is stored elsewhere, update `DATA_PATH` in `settings.py`.
+Images are loaded in grayscale by default. The grayscale statistics are:
+  - `CITYSCAPES_MEAN_GRAY=0.2986`
+  - `CITYSCAPES_STD_GRAY=0.1881`
+  - Set `model.params.input_channels` to `1` when training on these images as
+    in `configs/superpoint_cityscapes_finetune.yaml`.
 
 Example commands using the Cityscapes configs:
 

--- a/configs/magicpoint_cityscape_export.yaml
+++ b/configs/magicpoint_cityscape_export.yaml
@@ -1,6 +1,7 @@
 data:
     dataset: 'Cityscapes'  # 'coco' 'hpatches'
     export_folder: 'val' # train, val
+    grayscale: true      # load images as grayscale
     preprocessing:
         resize: [240, 320]
         # resize: [480, 640]
@@ -39,8 +40,8 @@ training:
 model:
     # name: 'SuperPointNet' # 'SuperPointNet_gauss2'
     name: 'SuperPointNet_gauss2' # 'SuperPointNet_gauss2'
-    # instruct the network to process RGB images
-    params: {input_channels: 3}
+    # instruct the network to process grayscale images
+    params: {input_channels: 1}
     batch_size: 8
     eval_batch_size: 8
     detection_threshold: 0.015 # 0.015

--- a/configs/superpoint_cityscapes_export.yaml
+++ b/configs/superpoint_cityscapes_export.yaml
@@ -8,6 +8,7 @@ data:
     export_folder: 'val'             # choose split
     root: 'datasets/Cityscapes'      # path to Cityscapes images
     segmentation_labels: 'datasets/Cityscapes/gtFine'  # segmentation masks
+    grayscale: true                  # load images as single-channel
     preprocessing:
         resize: [256, 512] #[512, 1024]
     reduce_to_4_categories: true
@@ -36,9 +37,9 @@ front_end_model: 'Val_model_heatmap'  # 'Train_model_frontend'
 
 model:
     name: 'SuperPointNet_gauss2'
-    # match the RGB inputs of the Cityscapes dataset
+    # match the grayscale inputs of the Cityscapes dataset
     params:
-        input_channels: 3
+        input_channels: 1
     lambda_segmentation: 1.0
     num_segmentation_classes: 4
 

--- a/datasets/Cityscapes.py
+++ b/datasets/Cityscapes.py
@@ -56,7 +56,8 @@ class Cityscapes(data.Dataset):
         'truncate': 0,
         'load_segmentation': True,
         # when true, images are returned as single-channel grayscale
-        'grayscale': False,
+        # default now set to True so Cityscapes is processed like COCO
+        'grayscale': True,
         'preprocessing': {
             'resize': [256, 512]
         },


### PR DESCRIPTION
## Summary
- process Cityscapes images in grayscale by default
- adjust Cityscapes export configs to use grayscale inputs
- update README to mention grayscale stats