### PR TITLE
Fix channel handling in homography adaptation export

### DIFF
--- a/export.py
+++ b/export.py
@@ -460,6 +460,12 @@ def export_detector_homoAdapt_gpu(config, output_dir, args):
         img = img.squeeze(0)
         img_2D = sample["image_2D"].numpy().squeeze()
         mask_2D = mask_2D.squeeze(0)
+        # inputs are (N, H, W) when the dataset outputs grayscale views
+        # restore explicit channel dimension expected by the network
+        if img.dim() == 3:
+            img = img.unsqueeze(1)
+        if mask_2D.dim() == 3:
+            mask_2D = mask_2D.unsqueeze(1)
 
         inv_homographies, homographies = (
             sample["homographies"],


### PR DESCRIPTION
## Summary
- fix incorrect channel dimension when exporting with homography adaptation
- add comments clarifying shape expectations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686e509dc41c8329a56767d68752ad2b