### PR TITLE
Avoid in-place tb_img mutation when unnormalizing

### DIFF
--- a/Train_model_frontend.py
+++ b/Train_model_frontend.py
@@ -724,6 +724,8 @@ class Train_model_frontend(object):
 
     def _unnormalize_img(self, img):
         """Undo dataset normalization before TensorBoard logging."""
+        # clone to ensure tb_imgs tensors remain unmodified
+        img = img.clone()
         dataset = self.config.get("data", {}).get("dataset", "")
         if dataset == "Cityscapes":
             if img.shape[0] == 1:


### PR DESCRIPTION
## Summary
- clone image tensors inside `_unnormalize_img` before applying mean/std

The previous implementation of `_unnormalize_img` modified the passed tensor in place. Because `tb_images_dict` forwarded views of `tb_imgs`, this altered the original dictionary entries. The function now clones the tensor first so callers receive the adjusted image without touching `tb_imgs`.