### PR TITLE
Add warp_to_canvas helper and demo script

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,8 +319,21 @@ python evaluation.py logs/sift_test/predictions --sift --repeatibility --homogra
 ```shell
 # show images saved in the folders
 jupyter notebook
-notebooks/visualize_hpatches.ipynb 
+notebooks/visualize_hpatches.ipynb
 ```
+
+## Debugging
+Use `utils.draw.warp_to_canvas` to visualise how a homography projects an
+image beyond its original boundaries. The helper wraps `cv2.warpPerspective`
+and draws the result on a blank canvas.
+
+```python
+from utils.draw import warp_to_canvas
+canvas = warp_to_canvas(img, H, out_size=(640, 480))
+```
+
+Run `python test/visualize_warping.py path/to/npz --canvas-size 640 480` to
+save an example visualization.
 
 ## Updates (year.month.day)
 - 2020.08.05: 

--- a/test/visualize_warping.py
+++ b/test/visualize_warping.py
@@ -1,96 +1,58 @@
-"""Testing file (not sorted yet)
-
-import torch
-import numpy as np
-
-
-from utils.utils import inv_warp_image_batch
-from numpy.linalg import inv
-import cv2
-import matplotlib.pyplot as plt
-from utils.draw import plot_imgs
-
-from utils.utils import pltImshow
-path = 'logs/magicpoint_synth_homoAdapt_cityscape/predictions/train'
-for i in range(10):
-    data = np.load(path + str(i) + '.npz')
-    # p1 = '/home/yoyee/Documents/deepSfm/datasets/HPatches/v_abstract/1.ppm'
-    # p2 = '/home/yoyee/Documents/deepSfm/datasets/HPatches/v_abstract/2.ppm'
-    # H = '/home/yoyee/Documents/deepSfm/datasets/HPatches/v_abstract/H_1_2'
-    # img = np.load(p1)
-    # warped_img = np.load(p2)
-
-    H = data['homography']
-    img1 = data['image'][:,:,np.newaxis]
-    img2 = data['warped_image'][:,:,np.newaxis]
-    # warped_img_H = inv_warp_image_batch(torch.tensor(img), torch.tensor(inv(H)))
-    warped_img1 = cv2.warpPerspective(img1, H, (img1.shape[1], img1.shape[0]))
-
-
-    # img_cat = np.concatenate((img, warped_img, warped_img_H), axis=1)
-    # pltImshow(img_cat)
-
-    # from numpy.linalg import inv
-    # warped_img1 = cv2.warpPerspective(img1, inv(H), (img2.shape[1], img2.shape[0]))
-    img1 = np.concatenate([img1, img1, img1], axis=2)
-    warped_img1 = np.stack([warped_img1, warped_img1, warped_img1], axis=2)
-    img2 = np.concatenate([img2, img2, img2], axis=2)
-    plot_imgs([img1, img2, warped_img1], titles=['img1', 'img2', 'warped_img1'], dpi=200)
-    plt.savefig( 'test' + str(i) + '.png')
-
-    """
-    
-import os,sys
-
-# Add the project’s root directory (one level up) to Python’s import path:
-SCRIPT_DIR   = os.path.dirname(os.path.abspath(__file__))
-PROJECT_ROOT = os.path.abspath(os.path.join(SCRIPT_DIR, '..'))
-sys.path.insert(0, PROJECT_ROOT)
-
+import argparse
 import glob
+import os
 
 import cv2
 import numpy as np
-import torch
 import matplotlib.pyplot as plt
 from tqdm import tqdm
 
-from numpy.linalg import inv
-from utils.utils import inv_warp_image_batch, pltImshow
-from utils.draw import plot_imgs
+from utils.draw import plot_imgs, warp_to_canvas
 
-# point this to your folder containing the .npz predictions
-base_dir = r'.'
 
-# find and sort all .npz files
-npz_paths = sorted(glob.glob(os.path.join(base_dir, '*.npz')))
+def main(args):
+    """Generate visualizations for each prediction archive."""
+    npz_paths = sorted(glob.glob(os.path.join(args.dir, "*.npz")))
 
-for npz_path in tqdm(npz_paths):
-    # load the archive
-    data = np.load(npz_path)
-    H = data['homography']            # (3×3)
-    img1 = data['image'][..., np.newaxis]       # (H×W×1)
-    img2 = data['warped_image'][..., np.newaxis]  # (H×W×1)
+    for npz_path in tqdm(npz_paths):
+        data = np.load(npz_path)
+        H = data["homography"]
+        img1 = data["image"][..., np.newaxis]
+        img2 = data["warped_image"][..., np.newaxis]
 
-    # warp img1 by H
-    # OpenCV wants (width, height)
-    h, w = img1.shape[:2]
-    warped_img1 = cv2.warpPerspective(img1, H.astype(np.float32), (w, h))
+        h, w = img1.shape[:2]
+        out_size = tuple(args.canvas_size) if args.canvas_size else (w, h)
 
-    # convert to 3-channel for plotting
-    img1_rgb       = np.repeat(img1,       3, axis=2)
-    img2_rgb       = np.repeat(img2,       3, axis=2)
-    warped_img1_rgb = np.repeat(warped_img1, 3, axis=2)
+        warped = warp_to_canvas(img1, H.astype(np.float32), out_size)
 
-    # plot and save
-    plot_imgs(
-        [img1_rgb, img2_rgb, warped_img1_rgb],
-        titles=['img1', 'img2', 'warped_img1'],
-        dpi=200
+        img1_rgb = np.repeat(img1, 3, axis=2)
+        img2_rgb = np.repeat(img2, 3, axis=2)
+        warped_rgb = np.repeat(warped, 3, axis=2)
+
+        plot_imgs(
+            [img1_rgb, img2_rgb, warped_rgb],
+            titles=["img1", "img2", "warp_to_canvas"],
+            dpi=200,
+        )
+
+        base_name = os.path.splitext(os.path.basename(npz_path))[0]
+        out_path = os.path.join(args.dir, f"test_{base_name}.png")
+        plt.savefig(out_path)
+        print(f"Saved visualization to {out_path}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Visualize homography warping using warp_to_canvas"
     )
-
-    # build a matching save name, e.g. test_aachen_000000_000019.png
-    base_name = os.path.splitext(os.path.basename(npz_path))[0]
-    out_path = os.path.join(base_dir, f'test_{base_name}.png')
-    plt.savefig(out_path)
-    print(f'Saved visualization to {out_path}')
+    parser.add_argument(
+        "dir", help="Directory containing *.npz prediction files"
+    )
+    parser.add_argument(
+        "--canvas-size",
+        metavar=("W", "H"),
+        type=int,
+        nargs=2,
+        help="Size of the output canvas (width height)",
+    )
+    main(parser.parse_args())

--- a/utils/draw.py
+++ b/utils/draw.py
@@ -278,3 +278,38 @@ def draw_homography_grid(img, H, spacing=32):
 
     return overlay
 
+
+def warp_to_canvas(img, H, out_size):
+    """Warp ``img`` by ``H`` and place it on a blank canvas.
+
+    Parameters
+    ----------
+    img : ``numpy.ndarray``
+        Single image, either grayscale ``(H, W)`` or color ``(H, W, 3)``.
+    H : ``numpy.ndarray``
+        ``3×3`` homography matrix used for projection.
+    out_size : tuple
+        Size of the output canvas given as ``(width, height)``.
+
+    Returns
+    -------
+    ``numpy.ndarray``
+        Zero initialised canvas with the warped image drawn on it.
+    """
+
+    # OpenCV expects the size as (width, height)
+    w, h = out_size
+    # warp the input image according to the given homography
+    warped = cv2.warpPerspective(img, H, (w, h))
+
+    # ensure the canvas has a channel dimension
+    if warped.ndim == 2:
+        canvas = np.zeros((h, w), dtype=img.dtype)
+    else:
+        canvas = np.zeros((h, w, warped.shape[2]), dtype=img.dtype)
+
+    # copy warped image onto the blank canvas
+    canvas[:warped.shape[0], :warped.shape[1]] = warped
+
+    return canvas
+


### PR DESCRIPTION
## Summary
- add `warp_to_canvas` to utils.draw for projecting images on a larger canvas
- clean up and update `test/visualize_warping.py` to use the helper
- document the helper usage in the README