### PR TITLE
Add SummaryWriter cleanup

### DIFF
--- a/export.py
+++ b/export.py
@@ -218,6 +218,8 @@ def export_descriptor(config, output_dir, args):
         # print("save: ", path)
         count += 1
     print("output pairs: ", count)
+    # close tensorboard writer to avoid duplicate plugin errors
+    writer.close()
 
 
 @torch.no_grad()

--- a/export_classical.py
+++ b/export_classical.py
@@ -179,6 +179,8 @@ def export_descriptor(config, output_dir, args):
     save_file = save_output / "export.txt"
     with open(save_file, "a") as myfile:
         myfile.write("output pairs: " + str(count) + '\n')
+    # close tensorboard writer to prevent duplicate plugin registration
+    writer.close()
     pass
 
 

--- a/train4.py
+++ b/train4.py
@@ -95,6 +95,8 @@ def train_joint(config, output_dir, args):
         print ("press ctrl + c, save model!")
         train_agent.saveModel()
         pass
+    # close tensorboard writer to prevent duplicate plugin registration
+    writer.close()
 
 if __name__ == '__main__':
     # global var


### PR DESCRIPTION
## Summary
- close SummaryWriter in `export.py`
- close SummaryWriter in `export_classical.py`
- close SummaryWriter in `train4.py`

These writers were previously left open, which could cause TensorBoard to register plugins multiple times if scripts are run in the same Python interpreter. Adding `writer.close()` prevents the `Duplicate plugins for name projector` error.