### PR TITLE
Add sidebar controls with layer store

### DIFF
--- a/webapp/LayerStore.ts
+++ b/webapp/LayerStore.ts
@@ -1,0 +1,33 @@
+export type LayerName = 'segmentation' | 'keypoints' | 'matching' | 'confidence';
+
+// State object holds the visibility of each layer in a single location
+const state: Record<LayerName, boolean> = {
+  segmentation: true,
+  keypoints: true,
+  matching: true,
+  confidence: true,
+};
+
+// EventTarget allows other modules to listen for changes
+const emitter = new EventTarget();
+
+export function getLayer(name: LayerName) {
+  return state[name];
+}
+
+export function setLayer(name: LayerName, value: boolean) {
+  state[name] = value;
+  // notify listeners that a layer visibility changed
+  emitter.dispatchEvent(
+    new CustomEvent('layerChange', { detail: { layer: name, visible: value } })
+  );
+}
+
+export function addLayerListener(listener: (evt: CustomEvent) => void) {
+  // addEventListener typed as EventListener, cast to handle CustomEvent
+  emitter.addEventListener('layerChange', listener as EventListener);
+}
+
+export function removeLayerListener(listener: (evt: CustomEvent) => void) {
+  emitter.removeEventListener('layerChange', listener as EventListener);
+}

--- a/webapp/Sidebar.tsx
+++ b/webapp/Sidebar.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useState } from 'react';
+import { getLayer, setLayer, LayerName, addLayerListener, removeLayerListener } from './LayerStore';
+
+// map to render label for each checkbox
+const layers: Record<LayerName, string> = {
+  segmentation: 'Segmentation',
+  keypoints: 'Keypoints',
+  matching: 'Matching',
+  confidence: 'Confidence',
+};
+
+export const Sidebar: React.FC = () => {
+  // local state mirrors the store state so UI stays reactive
+  const [visibility, setVisibility] = useState(() => {
+    const state: Record<LayerName, boolean> = {
+      segmentation: getLayer('segmentation'),
+      keypoints: getLayer('keypoints'),
+      matching: getLayer('matching'),
+      confidence: getLayer('confidence'),
+    };
+    return state;
+  });
+
+  useEffect(() => {
+    // update component when store changes via external actions
+    const listener = (evt: Event) => {
+      const detail = (evt as CustomEvent).detail as { layer: LayerName; visible: boolean };
+      setVisibility(prev => ({ ...prev, [detail.layer]: detail.visible }));
+    };
+    addLayerListener(listener);
+    // cleanup when unmounting
+    return () => removeLayerListener(listener);
+  }, []);
+
+  const onToggle = (layer: LayerName) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.checked;
+    // update store so other views are notified
+    setLayer(layer, value);
+  };
+
+  return (
+    <div className="sidebar">
+      {Object.entries(layers).map(([name, label]) => (
+        <label key={name} style={{ display: 'block' }}>
+          <input
+            type="checkbox"
+            checked={visibility[name as LayerName]}
+            onChange={onToggle(name as LayerName)}
+          />
+          {label}
+        </label>
+      ))}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- create `LayerStore` to keep visibility of viewer layers in one place
- add a React `Sidebar` with checkboxes for Segmentation, Keypoints, Matching and Confidence
- dispatch custom events whenever a checkbox changes so the main viewer can react