### PR TITLE
Add optional mixed precision training

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ datasets/ ($DATA_DIR)
 
 Example commands using the Cityscapes configs:
 
+Mixed precision can be enabled by setting `amp: true` in the YAML file. This
+activates PyTorch's autocast and `GradScaler` during training.
+
 ```bash
 # training
 python train4.py train_joint configs/superpoint_cityscapes_finetune.yaml superpoint_cityscapes --eval

--- a/configs/superpoint_cityscapes_finetune.yaml
+++ b/configs/superpoint_cityscapes_finetune.yaml
@@ -102,3 +102,11 @@ truncate: 1000
 pretrained: 'logs/superpoint_coco/checkpoints/superPointNet_2300_checkpoint.pth.tar'
     # pretrained: 'logs/superpoint_coco_heat2_0/checkpoints/superPointNet_90000_checkpoint.pth.tar'
 
+# enable mixed precision training
+amp: true
+amp_dtype: fp16
+grad_scaler:
+    enabled: true
+    init_scale: 65536
+    growth_interval: 2000
+


### PR DESCRIPTION
## Summary
- add AMP import and configuration defaults
- set up GradScaler in training classes
- wrap model forward and loss with autocast
- support AMP step in backward pass
- document `amp` config flag in README
- update Cityscapes finetune config with AMP options