### PR TITLE
Fix blank plotly graph in dashboard

### DIFF
--- a/streamlit_dashboard.py
+++ b/streamlit_dashboard.py
@@ -327,7 +327,8 @@ if experiment_name:
                         y=tags,
                         labels={"value": "Value", "variable": "Metric"},
                     )
-                    st.plotly_chart(fig)
+                    fig.update_layout(template="plotly_dark")  # match dark theme
+                    st.plotly_chart(fig, use_container_width=True)  # ensure full width
         else:
             st.warning("No valid data found in TensorBoard logs.")
 


### PR DESCRIPTION
## Summary
- tweak plotly chart layout in `streamlit_dashboard.py`
- use a dark plotly theme and enable full-width rendering so plots show up correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887f691c0988329a3ed51556b5b6043