### PR TITLE
Fix Plotly display in Streamlit dashboard

### DIFF
--- a/streamlit_dashboard.py
+++ b/streamlit_dashboard.py
@@ -329,6 +329,8 @@ if experiment_name:
                     )
                     fig.update_layout(template="plotly_dark")  # match dark theme
                     st.plotly_chart(fig, use_container_width=True)  # ensure full width
+                    # Also display in a browser when executed outside Streamlit
+                    fig.show()
         else:
             st.warning("No valid data found in TensorBoard logs.")
 


### PR DESCRIPTION
## Summary
- ensure Plotly graph is visible outside of Streamlit